### PR TITLE
UX: colors of events in the calendar as in the type

### DIFF
--- a/lib/presentation/pages/schedule/widgets/lesson_card.dart
+++ b/lib/presentation/pages/schedule/widgets/lesson_card.dart
@@ -20,7 +20,7 @@ class LessonCard extends StatelessWidget {
     required this.timeEnd,
   }) : super(key: key);
 
-  Color _getColorByType(String lessonType) {
+  static Color getColorByType(String lessonType) {
     if (lessonType.contains('лк') || lessonType.contains('лек'))
       return DarkThemeColors.colorful01;
     else if (lessonType.contains('лб') || lessonType.contains('лаб'))
@@ -96,7 +96,7 @@ class LessonCard extends StatelessWidget {
                 alignment: Alignment.center,
                 decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(100),
-                    color: _getColorByType(type)),
+                    color: getColorByType(type)),
                 height: 24,
                 // width: 10 * 7,
                 child: Text(type, style: DarkTextTheme.chip),

--- a/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
+++ b/lib/presentation/pages/schedule/widgets/schedule_page_view.dart
@@ -105,6 +105,26 @@ class _SchedulePageViewState extends State<SchedulePageView> {
         TableCalendar(
           // pageJumpingEnabled: true,
           weekendDays: const [DateTime.sunday],
+          calendarBuilders: CalendarBuilders(
+            markerBuilder: (context, day, events) {
+              return Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(
+                  events.length,
+                  (index) => Container(
+                    width: 6,
+                    height: 6,
+                    margin: const EdgeInsets.symmetric(horizontal: 0.3),
+                    decoration: new BoxDecoration(
+                      color: LessonCard.getColorByType(
+                          (events[index] as Lesson).types),
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
           calendarFormat: _calendarFormat,
           firstDay: Calendar.getSemesterStart(),
           lastDay:


### PR DESCRIPTION
Resolved #38 
![image](https://user-images.githubusercontent.com/51058739/131018953-83fd3d22-47a5-42f7-bcd5-cdc1b130db27.png)
Цвета ивентов теперь соответствуют цветам в типах пар. 