### PR TITLE
feature: add min/max zoom limit for photos in news

### DIFF
--- a/lib/presentation/widgets/images_view_gallery.dart
+++ b/lib/presentation/widgets/images_view_gallery.dart
@@ -65,6 +65,8 @@ class _ImagesViewGalleryState extends State<ImagesViewGallery> {
                 return PhotoViewGalleryPageOptions(
                   imageProvider: NetworkImage(widget.imageUrls[index]),
                   initialScale: PhotoViewComputedScale.contained * 0.8,
+                  minScale: PhotoViewComputedScale.contained * 0.6,
+                  maxScale: PhotoViewComputedScale.covered * 5.9,
                   heroAttributes: PhotoViewHeroAttributes(tag: widget.imageUrls[index]),
                 );
               },


### PR DESCRIPTION
В #217 есть 3 пункта:

- [x] Добавить свайпы влево/вправо для листания фотографий
- [ ] Добавить свайпы вверх/вниз для выхода из показа фотографии на весь экран
- [x] Ограничить масштабирование

Свайпы вверх/вниз для выхода из показа фотографии на весь экран с [текущей библиотекой ](https://pub.dev/packages/photo_view) добавить нельзя - https://github.com/bluefireteam/photo_view/issues/265