### PR TITLE
fix: lesson type check, add support shorthand notation for lessonType

### DIFF
--- a/api/packages/rtu_mirea_schedule_api_client/lib/src/fields_data_parsers.dart
+++ b/api/packages/rtu_mirea_schedule_api_client/lib/src/fields_data_parsers.dart
@@ -48,25 +48,7 @@ List<Classroom> getClassroomsFromLocationText(String location) {
 
 /// Parse lesson type from the text.
 LessonType getLessonTypeFromText(String lessonType) {
-  final parsedLessonType = _getLessonTypeByAbbreviation(lessonType.trim());
-
-  if (parsedLessonType != LessonType.unknown) {
-    return parsedLessonType;
-  }
-
-  if (lessonType.contains('Экзамен') || lessonType.contains('Э')) {
-    return LessonType.exam;
-  } else if (lessonType.contains('Зачет') || lessonType.contains('З')) {
-    return LessonType.credit;
-  } else if (lessonType.contains('Консультация')) {
-    return LessonType.consultation;
-  } else if (lessonType.contains('Курсовая работа')) {
-    return LessonType.courseWork;
-  } else if (lessonType.contains('Курсовой проект')) {
-    return LessonType.courseProject;
-  }
-
-  return LessonType.unknown;
+  return _getLessonTypeByAbbreviation(lessonType.trim());
 }
 
 LessonType _getLessonTypeByAbbreviation(String abbreviation) {
@@ -84,11 +66,15 @@ LessonType _getLessonTypeByAbbreviation(String abbreviation) {
     case 'КР':
       return LessonType.courseProject;
     case 'ЭКЗ':
+    case 'Э':
       return LessonType.exam;
     case 'ЗАЧ':
+    case 'З':
       return LessonType.credit;
     case 'ЛАБ':
       return LessonType.laboratoryWork;
+    case 'КТ':
+      return LessonType.consultation;
 
     default:
       return LessonType.unknown;

--- a/api/packages/rtu_mirea_schedule_api_client/lib/src/fields_data_parsers.dart
+++ b/api/packages/rtu_mirea_schedule_api_client/lib/src/fields_data_parsers.dart
@@ -54,9 +54,9 @@ LessonType getLessonTypeFromText(String lessonType) {
     return parsedLessonType;
   }
 
-  if (lessonType.contains('Экзамен')) {
+  if (lessonType.contains('Экзамен') || lessonType.contains('Э')) {
     return LessonType.exam;
-  } else if (lessonType.contains('Зачет')) {
+  } else if (lessonType.contains('Зачет') || lessonType.contains('З')) {
     return LessonType.credit;
   } else if (lessonType.contains('Консультация')) {
     return LessonType.consultation;


### PR DESCRIPTION
Изменился формат сокращений в rtu_mirea_schedule_api_client. Добавлена проверка сокращенного варианта "З" для зачёта и "Э" для экзамена .