### PR TITLE
Automate beta releases

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,295 @@
+name: Beta Release
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: beta-release-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    outputs:
+      build_name: ${{ steps.metadata.outputs.build_name }}
+      build_number: ${{ steps.metadata.outputs.build_number }}
+      release_sha: ${{ steps.metadata.outputs.release_sha }}
+      release_version: ${{ steps.metadata.outputs.release_version }}
+      tag: ${{ steps.metadata.outputs.tag }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
+
+      - name: Prepare release metadata
+        id: metadata
+        shell: bash
+        run: |
+          release_sha="$(git rev-parse HEAD)"
+          source_version="$(sed -n 's/^version:[[:space:]]*//p' pubspec.yaml)"
+          build_name="${source_version%%+*}"
+          test "$GITHUB_RUN_ATTEMPT" -le 99
+          build_number="$((1000000 + GITHUB_RUN_NUMBER * 100 + GITHUB_RUN_ATTEMPT))"
+          test -n "$build_name"
+          test "$build_number" -gt 0
+          test "$build_number" -le 2100000000
+          release_version="$build_name+$build_number"
+          tag="v$build_name-beta.$build_number"
+          {
+            echo "build_name=$build_name"
+            echo "build_number=$build_number"
+            echo "release_sha=$release_sha"
+            echo "release_version=$release_version"
+            echo "tag=$tag"
+          } >> "$GITHUB_OUTPUT"
+
+  android:
+    name: Android beta
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: beta
+    defaults:
+      run:
+        shell: bash
+    env:
+      SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify release configuration
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          NFC_MODULE_DEPLOY_KEY: ${{ secrets.NFC_MODULE_DEPLOY_KEY }}
+          UNIVERSITY_CONFIG_JSON: ${{ vars.UNIVERSITY_CONFIG_JSON }}
+          FIREBASE_CONFIG_JSON: ${{ vars.FIREBASE_CONFIG_JSON }}
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
+        run: |
+          required=(
+            SHOREBIRD_TOKEN
+            ANDROID_KEYSTORE_BASE64
+            ANDROID_KEYSTORE_PASSWORD
+            ANDROID_KEY_ALIAS
+            ANDROID_KEY_PASSWORD
+            NFC_MODULE_DEPLOY_KEY
+            UNIVERSITY_CONFIG_JSON
+            FIREBASE_CONFIG_JSON
+            SUPABASE_URL
+            SUPABASE_PUBLISHABLE_KEY
+          )
+          missing=()
+          for name in "${required[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing beta release configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Check out private NFC module
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: 0niel/university-app-nfc-private
+          ref: 6226b9b4c3f2ed2c4a0727ae062f8a5239e5aba5
+          ssh-key: ${{ secrets.NFC_MODULE_DEPLOY_KEY }}
+          path: android/private/nfc-pass-android
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: stable
+          flutter-version-file: .fvmrc
+          cache: true
+
+      - name: Set up Shorebird
+        uses: shorebirdtech/setup-shorebird@4dd9d7dc2d7930bfeadb053b6e94b5110779d1e5 # v1
+        with:
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate code
+        run: dart run build_runner build
+
+      - name: Configure signing
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          python3 - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          Path("android/app/release.jks").write_bytes(
+              base64.b64decode(os.environ["ANDROID_KEYSTORE_BASE64"], validate=True)
+          )
+          Path("android/key.properties").write_text(
+              "\n".join(
+                  (
+                      f"storePassword={os.environ['ANDROID_KEYSTORE_PASSWORD']}",
+                      f"keyPassword={os.environ['ANDROID_KEY_PASSWORD']}",
+                      f"keyAlias={os.environ['ANDROID_KEY_ALIAS']}",
+                      "storeFile=release.jks",
+                  )
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Configure university
+        env:
+          UNIVERSITY_CONFIG_JSON: ${{ vars.UNIVERSITY_CONFIG_JSON }}
+          FIREBASE_CONFIG_JSON: ${{ vars.FIREBASE_CONFIG_JSON }}
+        run: |
+          printf '%s\n' "$UNIVERSITY_CONFIG_JSON" > "$RUNNER_TEMP/university.json"
+          printf '%s\n' "$FIREBASE_CONFIG_JSON" > "$RUNNER_TEMP/firebase.json"
+          dart run tool/configure_university.dart \
+            --config "$RUNNER_TEMP/university.json"
+
+      - name: Release Android beta
+        id: shorebird
+        uses: shorebirdtech/shorebird-release@fb52cad53f4ed5ce39883d51a26916ead502b93d # v1
+        env:
+          ORG_GRADLE_PROJECT_requirePrivateNfcModule: "true"
+          SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
+        with:
+          platform: android
+          flutter-version: 3.44.2
+          args: >-
+            --artifact apk
+            --flavor production
+            --build-name ${{ needs.prepare.outputs.build_name }}
+            --build-number ${{ needs.prepare.outputs.build_number }}
+            --
+            --dart-define-from-file=${{ runner.temp }}/university.json
+            --dart-define-from-file=${{ runner.temp }}/firebase.json
+            --dart-define=SUPABASE_URL=${{ vars.SUPABASE_URL }}
+            --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
+
+      - name: Collect artifacts
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+        run: |
+          apk="build/app/outputs/flutter-apk/app-production-release.apk"
+          aab="build/app/outputs/bundle/productionRelease/app-production-release.aab"
+          test -s "$apk"
+          test -s "$aab"
+          mkdir -p dist
+          cp "$apk" "dist/university-app-$RELEASE_VERSION.apk"
+          cp "$aab" "dist/university-app-$RELEASE_VERSION.aab"
+          if [[ -s build/app/outputs/mapping/productionRelease/mapping.txt ]]; then
+            cp build/app/outputs/mapping/productionRelease/mapping.txt \
+              "dist/university-app-$RELEASE_VERSION-mapping.txt"
+          fi
+          if [[ -s build/app/outputs/native-debug-symbols/productionRelease/native-debug-symbols.zip ]]; then
+            cp build/app/outputs/native-debug-symbols/productionRelease/native-debug-symbols.zip \
+              "dist/university-app-$RELEASE_VERSION-native-symbols.zip"
+          fi
+          (cd dist && shasum -a 256 ./* > SHA256SUMS)
+
+      - name: Upload Android artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: android-beta-${{ needs.prepare.outputs.release_version }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+
+      - name: Remove signing material
+        if: always()
+        run: rm -f android/key.properties android/app/release.jks
+
+  publish:
+    name: Publish beta
+    needs:
+      - prepare
+      - android
+    runs-on: ubuntu-latest
+    environment:
+      name: beta
+      url: >-
+        https://github.com/${{ github.repository }}/releases/tag/${{ needs.prepare.outputs.tag }}
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: android-beta-${{ needs.prepare.outputs.release_version }}
+          path: dist
+
+      - name: Attest artifacts
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: dist/*
+
+      - name: Publish GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/* \
+              --clobber \
+              --repo "$GITHUB_REPOSITORY"
+            gh release edit "$TAG" \
+              --prerelease \
+              --target "$RELEASE_SHA" \
+              --title "Beta $RELEASE_VERSION" \
+              --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$TAG" dist/* \
+              --generate-notes \
+              --prerelease \
+              --target "$RELEASE_SHA" \
+              --title "Beta $RELEASE_VERSION" \
+              --repo "$GITHUB_REPOSITORY"
+          fi

--- a/docs/university-configuration.md
+++ b/docs/university-configuration.md
@@ -97,8 +97,24 @@ Generated platform files and `config/university.local.json` are ignored because
 they represent a developer's selected tenant. Review the generated text before
 connecting it to a release build.
 
-The manual Shorebird workflow reads the same JSON from the public repository
-variable `UNIVERSITY_CONFIG_JSON`, validates it with this generator, and passes
-it to Flutter as a Dart define file. Firebase identifiers come from the separate
+The release workflows read the same JSON from the repository variable
+`UNIVERSITY_CONFIG_JSON`, validate it with this generator, and pass it to
+Flutter as a Dart define file. Firebase identifiers come from the separate
 `FIREBASE_CONFIG_JSON` variable. Never point a release workflow at the example
 university configuration.
+
+## Automated beta releases
+
+Every successful `CI` run caused by a push to `master` starts the beta release
+workflow. It creates a Shorebird Android release, uploads the signed APK, AAB,
+mapping file, native symbols, and checksums as workflow artifacts, attests their
+provenance, and publishes them in a GitHub prerelease. A manual dispatch uses
+the same fail-closed path.
+
+The `beta` GitHub environment accepts protected branches only. Configure
+`UNIVERSITY_CONFIG_JSON`, `FIREBASE_CONFIG_JSON`, and `SUPABASE_URL` as
+repository variables. Configure `SUPABASE_PUBLISHABLE_KEY`, `SHOREBIRD_TOKEN`,
+`NFC_MODULE_DEPLOY_KEY`, `ANDROID_KEYSTORE_BASE64`,
+`ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, and `ANDROID_KEY_PASSWORD`
+as repository secrets. The signing values must identify the same long-lived
+Android key for every beta so installed builds remain upgradeable.

--- a/lib/schedule/view/schedule_page.dart
+++ b/lib/schedule/view/schedule_page.dart
@@ -108,6 +108,7 @@ class _SchedulePageState extends State<SchedulePage> with _ScheduleClockTicker {
   late PageController _weekController;
   late PageController _monthController;
   late int _monthTargetPage;
+  late int _monthPreferredDay;
   int _pagerGuards = 0;
   int _monthPagerGuards = 0;
 
@@ -133,6 +134,7 @@ class _SchedulePageState extends State<SchedulePage> with _ScheduleClockTicker {
       initialPage: _paging.weekPageOfDayPage(page),
     );
     _monthTargetPage = _monthPaging.pageOf(_selectedDay);
+    _monthPreferredDay = _selectedDay.day;
     _monthController = PageController(initialPage: _monthTargetPage);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -477,7 +479,10 @@ class _SchedulePageState extends State<SchedulePage> with _ScheduleClockTicker {
       0,
       _monthPaging.pageCount - 1,
     );
-    _applySelectedDay(_monthPaging.dayInPage(target, _selectedDay.day));
+    _applySelectedDay(
+      _monthPaging.dayInPage(target, _monthPreferredDay),
+      preserveMonthDay: true,
+    );
     unawaited(
       _driveMonthPager(
         target,
@@ -566,11 +571,16 @@ class _SchedulePageState extends State<SchedulePage> with _ScheduleClockTicker {
     _syncMonthPager(next);
   }
 
-  void _applySelectedDay(DateTime day, {_ScheduleView? view}) {
+  void _applySelectedDay(
+    DateTime day, {
+    _ScheduleView? view,
+    bool preserveMonthDay = false,
+  }) {
     final monthChanged =
         day.year != _selectedDay.year || day.month != _selectedDay.month;
     setState(() {
       _selectedDay = day;
+      if (!preserveMonthDay) _monthPreferredDay = day.day;
       _showPast = false;
       if (view != null) _view = view;
     });
@@ -731,7 +741,10 @@ class _SchedulePageState extends State<SchedulePage> with _ScheduleClockTicker {
     _monthTargetPage = page;
     _selectorCollapse.value = 0;
     unawaited(HapticFeedback.selectionClick());
-    _applySelectedDay(_monthPaging.dayInPage(page, _selectedDay.day));
+    _applySelectedDay(
+      _monthPaging.dayInPage(page, _monthPreferredDay),
+      preserveMonthDay: true,
+    );
   }
 
   Future<void> _refreshSchedule() async {

--- a/test/tool/beta_release_workflow_test.dart
+++ b/test/tool/beta_release_workflow_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('publishes an attested beta after successful master CI', () {
+    final workflow = File(
+      '.github/workflows/beta-release.yml',
+    ).readAsStringSync();
+
+    expect(workflow, contains('workflow_run:'));
+    expect(workflow, contains('      - CI'));
+    expect(workflow, contains('      - master'));
+    expect(workflow, contains("workflow_run.conclusion == 'success'"));
+    expect(workflow, contains("workflow_run.event == 'push'"));
+    expect(workflow, contains('cancel-in-progress: false'));
+    expect(workflow, contains('shorebirdtech/shorebird-release@'));
+    expect(workflow, contains('--artifact apk'));
+    expect(workflow, contains('app-production-release.apk'));
+    expect(workflow, contains('app-production-release.aab'));
+    expect(workflow, contains('actions/upload-artifact@'));
+    expect(workflow, contains('actions/attest-build-provenance@'));
+    expect(workflow, contains(r'gh release create "$TAG"'));
+    expect(workflow, contains('--prerelease'));
+    expect(workflow, contains('if-no-files-found: error'));
+  });
+}


### PR DESCRIPTION
## Summary
- publish an Android beta automatically after every successful CI run on `master`
- build signed Shorebird APK and AAB artifacts with the protected NFC module
- attach mapping files, native symbols, checksums, and provenance attestations
- create an idempotent GitHub prerelease for each beta build
- guard the release trigger and artifact contract with a focused test
- preserve the selected calendar day while retargeting month animations across shorter months

## Validation
- full Dart analysis
- focused beta workflow test
- schedule responsive test suite
- DCM analysis
- actionlint validation
- Prettier validation
- private native boundary and history verification
- production tenant configuration validation